### PR TITLE
Package publishing directly to dapphub.io

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,8 +8,16 @@ var Dapphub = require('dapphub');
 // var Dapphubdb = require('../dapphub_registry.js');
 var Web3Factory = require('dapple-core/web3Factory.js');
 var deasync = require('deasync');
+var http = require('http');
 
-var createPackageHeader = function (contracts, rootHash, dappfile, schema) {
+// Will add complexity once there are live dapphub.io websites
+var options = {
+  hostname: 'localhost',
+  port: 3000,
+  method: 'POST'
+};
+
+var createPackageHeader = function (contracts, dappfile, schema) {
   // TODO - validate dappfile
 
   // TODO - include solc version
@@ -23,7 +31,7 @@ var createPackageHeader = function (contracts, rootHash, dappfile, schema) {
       flags: '--'
     },
     tags: dappfile.tags || [],
-    root: rootHash,
+    //root: rootHash, removing rootHash for now as we aren't using ipfs the same way
     contracts: contracts,
     dependencies: dappfile.dependencies || {},
     environments: dappfile.environments || {}
@@ -57,25 +65,27 @@ module.exports = function (opts) {
   return through.obj(function (file, enc, cb) {
     if (file.path === 'classes.json') {
       // Build Package Header
-      var contracts = processClasses(String(file.contents));
-      var rootHash = ipfs.addDirSync(opts.path);
+      // var contracts = processClasses(String(file.contents));
+      // var rootHash = ipfs.addDirSync(opts.path);
       // var schemaHash = ipfs.addJsonSync(schemas.package.schema);
-      var header = createPackageHeader(contracts, rootHash, opts.dappfile, ''); // shemaHash
-      var headerHash = ipfs.addJsonSync(header);
+      // var headerHash = ipfs.addJsonSync(header);
+      
+      var contracts = JSON.parse(String(file.contents))
+      var header = createPackageHeader(contracts, opts.dappfile, ''); // shemaHash
 
-      var web3 = deasync(opts.state.getRemoteWeb3.bind(opts.state))('MORDEN');
+      //var web3 = deasync(opts.state.getRemoteWeb3.bind(opts.state))('MORDEN');
 
       // Add package to dapphubDb
       // var web3 = Web3Factory.JSONRPC(opts);
 
-      let address = '0xc5ab3dabed7820c6612564f768a0d4f682379e0e';
+      // let address = '0xc5ab3dabed7820c6612564f768a0d4f682379e0e';
       // if ('registries' in opts.environment && opts.environment.registries.length > 0) {
       //   address = opts.environment.registries[0];
       // } else {
       //   address = Dapphub.getDappfile().environments.morden.objects.simplecontroller.address;
       // }
-      let registryClass = Dapphub.getClasses().DappHubSimpleController;
-      let dapphub = web3.eth.contract(JSON.parse(registryClass.interface)).at(address);
+      // let registryClass = Dapphub.getClasses().DappHubSimpleController;
+      // let dapphub = web3.eth.contract(JSON.parse(registryClass.interface)).at(address);
 
       // var dapphubdb = new Dapphubdb.Class(web3, 'morden');
       // var dapphub = dapphubdb.objects.dapphubdb;
@@ -88,26 +98,48 @@ module.exports = function (opts) {
         throw new Error(`Problem with your semver version in header: "${header.version}" has to match /\\d+\\.\\d+\\.\\d+/ e.g. (1.5.1)`);
       }
 
-      var fromAccount;
-      if (typeof opts === 'object' &&
-          'web3' in opts &&
-          'account' in opts.web3) {
-        fromAccount = opts.web3.account;
-      } else {
-        fromAccount = web3.eth.coinbase || web3.eth.accounts[0];
-      }
+      var req = http.request(_.extend(options, {
+        path: '/pkgHead',
+        headers: {
+          "content-type": "application/json"
+        }
+      }), function(res) {
+        res.setEncoding('utf8');
+        res.on('data', function (chunk) {
+          console.log(chunk);
+        });
+        res.on('end', function () {
+          console.log("Package published to Dapphub.io")
+        });
+      });
+
+      req.on('error', function(e) {
+        console.log('problem with request: ' + e.error);
+      });
+
+      req.write(JSON.stringify(header));
+      req.end();
+
+      // var fromAccount;
+      // if (typeof opts === 'object' &&
+      //     'web3' in opts &&
+      //     'account' in opts.web3) {
+      //   fromAccount = opts.web3.account;
+      // } else {
+      //   fromAccount = web3.eth.coinbase || web3.eth.accounts[0];
+      // }
 
       // PUBLISH the actual package
       // TODO - test if auth is valid and version is bigger then on the db
-      dapphub.setPackage(header.name, major, minor, patch, headerHash, {
-        from: fromAccount,
-        gas: 200000
-      }, function (err, res) {
-        if (err) throw err;
-        console.log(res);
-        console.log(`PUBLISH ${header.name}@${major}.${minor}.${patch}: ${headerHash}`);
-        cb();
-      });
+      // dapphub.setPackage(header.name, major, minor, patch, headerHash, {
+      //   from: fromAccount,
+      //   gas: 200000
+      // }, function (err, res) {
+      //   if (err) throw err;
+      //   console.log(res);
+      //   console.log(`PUBLISH ${header.name}@${major}.${minor}.${patch}: ${headerHash}`);
+      //   cb();
+      // });
     } else {
       this.push(file);
       cb();


### PR DESCRIPTION
Only pushing to localhost for now. I think we should explicitly filter out dapple environment contracts like DappleLogger and DappleEnvironment (see [this example](https://apm.keybase.pub/QmVhnz8HhH99ZoQfoPBukuYFjG7zrE7xCXtUyW6VvyL19g.json) for how it currently looks) in publish.js until dapple's linker works better. Review requested @mhhf 
